### PR TITLE
Skip ASG in case no instance is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Skip ASG in case no instance is present.
+
 ### Changed
 
 - add the use of runtime/default secccomp profile.

--- a/pkg/refresh/refresh.go
+++ b/pkg/refresh/refresh.go
@@ -95,6 +95,11 @@ func (s *InstanceRefreshService) Refresh(ctx context.Context, minHealthyPercenta
 			}
 		}
 
+		if len(asg.Instances) == 0 {
+			s.Scope.Info(fmt.Sprintf("ASG %s has no instances, skipping...", *asg.AutoScalingGroupName))
+			return nil
+		}
+
 		refreshInput := &autoscaling.StartInstanceRefreshInput{
 			AutoScalingGroupName: asg.AutoScalingGroupName,
 			DesiredConfiguration: &autoscaling.DesiredConfiguration{

--- a/pkg/refresh/refresh.go
+++ b/pkg/refresh/refresh.go
@@ -97,7 +97,7 @@ func (s *InstanceRefreshService) Refresh(ctx context.Context, minHealthyPercenta
 
 		if len(asg.Instances) == 0 {
 			s.Scope.Info(fmt.Sprintf("ASG %s has no instances, skipping...", *asg.AutoScalingGroupName))
-			return nil
+			continue
 		}
 
 		refreshInput := &autoscaling.StartInstanceRefreshInput{


### PR DESCRIPTION
This fixes a bug which let the operator crash in case ASG are not having EC2 instances.