### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
 ## [Unreleased]
 
 ### Added
-
 - Add `global.podSecurityStandards.enforced` value for PSS migration.
-
 ### Changed
 
+- Configure `gsoci.azurecr.io` as the default container image registry.
 - Upgraded `github.com/prometheus/client_golang` to `v1.11.1`.
 - Upgraded `golang.org/x/text` to `v0.3.8`.
 

--- a/helm/aws-rolling-node-operator/values.yaml
+++ b/helm/aws-rolling-node-operator/values.yaml
@@ -13,7 +13,7 @@ image:
   name: "giantswarm/aws-rolling-node-operator"
   tag: "[[ .Version ]]"
 registry:
-  domain: docker.io
+  domain: gsoci.azurecr.io
 
 pod:
   user:
@@ -43,7 +43,7 @@ securityContext:
   allowPrivilegeEscalation: false
   capabilities:
     drop:
-    - ALL
+      - ALL
 
 serviceMonitor:
   enabled: true


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
